### PR TITLE
Add benchmark to compare Iter.N to normal for loop

### DIFF
--- a/iter_test.go
+++ b/iter_test.go
@@ -27,3 +27,46 @@ func TestAllocs(t *testing.T) {
 		t.Errorf("allocs = %v", allocs)
 	}
 }
+
+// To benchmark, run: go test -bench=.
+
+// Global result variable to prevent compiler from optimizing calls away. It will
+// likely overflow but this doesn't matter since the actual value is never used
+var result int
+
+func benchIter(n int, b *testing.B) {
+	r := 0
+	for x := 0; x < b.N; x++ {
+		for i := range iter.N(n) {
+			r += i
+		}
+	}
+	result = r
+}
+
+func benchFor(n int, b *testing.B) {
+	r := 0
+	for x := 0; x < b.N; x++ {
+		for i := 0; i < n; i++ {
+			r += i
+		}
+	}
+	result = r
+}
+
+func BenchmarkIter1e0(b *testing.B) { benchIter(1e0, b) }
+func BenchmarkIter1e1(b *testing.B) { benchIter(1e1, b) }
+func BenchmarkIter1e2(b *testing.B) { benchIter(1e2, b) }
+func BenchmarkIter1e3(b *testing.B) { benchIter(1e3, b) }
+func BenchmarkIter1e4(b *testing.B) { benchIter(1e4, b) }
+func BenchmarkIter1e5(b *testing.B) { benchIter(1e5, b) }
+func BenchmarkIter1e6(b *testing.B) { benchIter(1e6, b) }
+
+// Function names padded to "01" for better aligned output.
+func BenchmarkFor01e0(b *testing.B) { benchFor(1e0, b) }
+func BenchmarkFor01e1(b *testing.B) { benchFor(1e1, b) }
+func BenchmarkFor01e2(b *testing.B) { benchFor(1e2, b) }
+func BenchmarkFor01e3(b *testing.B) { benchFor(1e3, b) }
+func BenchmarkFor01e4(b *testing.B) { benchFor(1e4, b) }
+func BenchmarkFor01e5(b *testing.B) { benchFor(1e5, b) }
+func BenchmarkFor01e6(b *testing.B) { benchFor(1e6, b) }


### PR DESCRIPTION
This adds benchmark code to compare the performance of `Iter.N` to an
init-condition-post for loop.

Based on this benchmark it looks like `Iter.N` has some overhead for very
small loops, but quickly becomes almost negligible for large loop values.

This is the output on my machine (Core i5-3470 3.20GHz, Windows 7 64-bit):

```
>go test -bench=.
PASS
BenchmarkIter1e0        100000000               13.7 ns/op
BenchmarkIter1e1        50000000                21.6 ns/op
BenchmarkIter1e2        20000000                84.6 ns/op
BenchmarkIter1e3         3000000               607 ns/op
BenchmarkIter1e4          200000              5860 ns/op
BenchmarkIter1e5           20000             60156 ns/op
BenchmarkIter1e6            2000            612561 ns/op
BenchmarkFor01e0        2000000000               0.92 ns/op
BenchmarkFor01e1        300000000                6.02 ns/op
BenchmarkFor01e2        20000000                62.2 ns/op
BenchmarkFor01e3         3000000               547 ns/op
BenchmarkFor01e4          300000              5703 ns/op
BenchmarkFor01e5           30000             58439 ns/op
BenchmarkFor01e6            2000            581558 ns/op
ok      github.com/bradfitz/iter        24.262s
```

In these results small loops incur a relatively large overhead
(e.g. n=10 takes 3.6x as long), but for larger loops the relative overhead
becomes much smaller (e.g. n=1 million takes 1.05x as long).
