### PR TITLE
iter: support more types for N()

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,1 +1,9 @@
-See http://godoc.org/github.com/bradfitz/iter
+Based on https://github.com/bradfitz/iter
+
+Now supports more types.
+
+Added empty interfaces, reflection and an allocation for good measure.
+
+Because sometimes you want to iterate over a *testing.B without having to type `b.N` or the length of a buffered channel without having to type `len(ch)`.
+
+See https://godoc.org/github.com/voutasaurus/iter

--- a/iter.go
+++ b/iter.go
@@ -75,7 +75,9 @@ func n(any interface{}) int {
 	case reflect.Array, reflect.Chan, reflect.Map, reflect.Slice, reflect.String:
 		return v.Len()
 	case reflect.Ptr, reflect.Interface:
-		return n(v.Elem().Interface())
+		if e := v.Elem(); e.IsValid() && e.CanInterface() {
+			return n(e.Interface())
+		}
 	case reflect.Struct:
 		if f := v.FieldByName("N"); f.IsValid() {
 			return n(f.Interface())

--- a/iter.go
+++ b/iter.go
@@ -1,7 +1,10 @@
 // Package iter provides a syntantically different way to iterate over integers. That's it.
 package iter
 
+import "reflect"
+
 // N returns a slice of n 0-sized elements, suitable for ranging over.
+// n is determined "appropriately" depending on the type and contents of v.
 //
 // For example:
 //
@@ -11,7 +14,73 @@ package iter
 //
 // ... will print 0 to 9, inclusive.
 //
-// It does not cause any allocations.
-func N(n int) []struct{} {
-	return make([]struct{}, n)
+// It causes one allocation.
+func N(v interface{}) []struct{} {
+	return make([]struct{}, n(v))
+}
+
+type Inter interface {
+	Int() int
+}
+
+func n(any interface{}) int {
+	if v, ok := any.(Inter); ok {
+		return v.Int()
+	}
+
+	switch v := any.(type) {
+	case int:
+		return v
+	case int8:
+		return int(v)
+	case int16:
+		return int(v)
+	case int32:
+		return int(v)
+	case int64:
+		return int(v)
+	case uint:
+		return int(v)
+	case uint8:
+		return int(v)
+	case uint16:
+		return int(v)
+	case uint32:
+		return int(v)
+	case uint64:
+		return int(v)
+	case uintptr:
+		return int(v)
+	case float32:
+		return int(v)
+	case float64:
+		return int(v)
+
+	case complex64:
+		return int(real(v))
+	case complex128:
+		return int(real(v))
+
+	case string:
+		return len(v)
+
+	case bool:
+		if v {
+			return 1
+		}
+		return 0
+	}
+
+	switch v := reflect.ValueOf(any); v.Kind() {
+	case reflect.Array, reflect.Chan, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len()
+	case reflect.Ptr, reflect.Interface:
+		return n(v.Elem().Interface())
+	case reflect.Struct:
+		if f := v.FieldByName("N"); f.IsValid() {
+			return n(f.Interface())
+		}
+	}
+
+	return 0
 }

--- a/iter_test.go
+++ b/iter_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/bradfitz/iter"
+	"github.com/voutasaurus/iter"
 )
 
 func ExampleN() {
@@ -23,7 +23,14 @@ func TestAllocs(t *testing.T) {
 	allocs := testing.AllocsPerRun(500, func() {
 		x = iter.N(1e9)
 	})
-	if allocs > 0.1 {
+	if allocs > 1.1 {
 		t.Errorf("allocs = %v", allocs)
+	}
+}
+
+func TestNest(t *testing.T) {
+	l := len(iter.N(&struct{ N []string }{N: make([]string, 42)}))
+	if l != 42 {
+		t.Errorf("expected: %d, got: %d", 42, l)
 	}
 }

--- a/iter_test.go
+++ b/iter_test.go
@@ -34,3 +34,26 @@ func TestNest(t *testing.T) {
 		t.Errorf("expected: %d, got: %d", 42, l)
 	}
 }
+
+func TestNil(t *testing.T) {
+	z := len(iter.N(nil))
+	if z != 0 {
+		t.Errorf("iter.N(nil): expected: 0, got: %d", z)
+	}
+}
+
+func TestNilPtr(t *testing.T) {
+	var x *int
+	z := len(iter.N(x))
+	if z != 0 {
+		t.Errorf("iter.N(nil): expected: 0, got: %d", z)
+	}
+}
+
+func TestNilInterface(t *testing.T) {
+	var x iter.Inter
+	z := len(iter.N(x))
+	if z != 0 {
+		t.Errorf("iter.N(nil): expected: 0, got: %d", z)
+	}
+}


### PR DESCRIPTION
@bmizerany did this today:
```
func n(b *testing.T) []struct{} {
        return make([]struct{}, b.N)
}

func BenchmarkNewParent(b *testing.B) {
        b.ReportAllocs()
        for range n(b) {
                
        }
}
```

I immediately thought of iter and felt compelled to write this.

Please enjoy my proposal for what iter could be.